### PR TITLE
IPv6 support for greylist and blackhole

### DIFF
--- a/README
+++ b/README
@@ -140,7 +140,7 @@ TESTING
 
    Now look in the greylist data for this entry:
 
-      ls /path/to/data/client_address/10/9/8/7/greylist/user1@example.com/user2@example.com
+      ls /path/to/data/client_address/ipv4/10/9/8/7/greylist/user1@example.com/user2@example.com
 
    Wait 10 minutes (or whatever you set the greylisting time to) and try
    it again.  This time, in response to your "rcpt to" line, you should
@@ -278,7 +278,7 @@ INSTALL INSTRUCTIONS
          #  set up directories
          mkdir -p "$TGSPROG" "$TGSDATA"/config
          mkdir "$TGSDATA"/data
-         chown -R nobody "$TGSDATA"/data
+         chown -R "$TGSUSER" "$TGSDATA"/data
          cp __default__.dist "$TGSDATA"/config/__default__
 
          #  install programs
@@ -313,7 +313,7 @@ INSTALL INSTRUCTIONS
       "/etc/cron.d" directory, and the following can be be used to add an
       entry:
 
-         echo 0 0 * * * $TGSUSER $TGSPROG/tumgreyspf-clean \
+         echo "0 0 * * * $TGSUSER $TGSPROG/tumgreyspf-clean" \
                >/etc/cron.d/tumgreyspf
 
       Otherwise, you will need to use "crontab -e -u $TGSUSER" to add the
@@ -333,7 +333,7 @@ INSTALL INSTRUCTIONS
       Add to your postfix master.cf:
 
          tumgreyspf  unix  -       n       n       -       -       spawn
-            user=nobody argv=$TGSPROG/tumgreyspf
+            user=$TGSUSER argv=$TGSPROG/tumgreyspf
 
       Next, main.cf must be configured so that "smtpd_recipient_restrictions"
       includes a call to the tumgreyspf policy filter.  If you already have

--- a/tumgreyspf
+++ b/tumgreyspf
@@ -16,6 +16,7 @@ import time
 import popen2
 import errno
 import spf
+import ipaddress
 sys.path.append('/usr/local/lib/tumgreyspf')
 import tumgreyspfsupp
 
@@ -37,12 +38,18 @@ def is_loopback(address):
     except ImportError:
         return False
 
+    if debugLevel >= 3:
+        syslog.syslog('is_loopback: testing "%s"' % address )
     loopback_cidrs = ['127.0.0.0/8', '::ffff:127.0.0.0/104', '::1/128']
-    compare = ipaddress.ip_interface(address).network.overlaps
+    compare = ipaddress.ip_interface(address.decode("utf-8")).network.overlaps
     for cidr in loopback_cidrs:
-        if compare(ipaddress.ip_interface(cidr).network):
+        if compare(ipaddress.ip_interface(cidr.decode("utf-8")).network):
+            if debugLevel >= 3:
+                syslog.syslog('is_loopback: "%s" is loopback address' % address )
             return True
 
+    if debugLevel >= 3:
+        syslog.syslog('is_loopback: "%s" is not a loopback address' % address )
     return False
 
 
@@ -178,13 +185,41 @@ def greylistcheck(data, configData, configGlobal):
     ip = data.get('client_address')
     if ip == None:
         return((None, None))
-    ipBytes = string.split(ip, '.')
-    if configGlobal['ignoreLastByte'] > 0:
-        ipBytes = ipBytes[:-1]
+
+    ipAddr = ipaddress.ip_address(ip.decode("utf-8"))
+
+    if debugLevel >= 3:
+        syslog.syslog('greylistcheck: client_address "%s" is ipVersion: "%s"' %( ip, ipAddr.version ) )
+
+    if ipAddr.version == 4:
+        ipVersion = "ipv4"
+        ipBytes = string.split(ip, '.')
+        if configGlobal['ipv4NetworkMask'] > 0 and configGlobal['ipv4NetworkMask'] < 32:
+            ipv4NetMask = str(configGlobal['ipv4NetworkMask'])
+        else:
+            ipv4NetMask = "32"
+        ipInterface = ipaddress.ip_interface(ip.decode("utf-8") + "/" + ipv4NetMask )
+        ipNetwork   = ipInterface.network
+        ipNetAddr   = ipNetwork.network_address.exploded
+        ipBytes     = string.split(ipNetAddr, '.')
+    elif ipAddr.version == 6:
+        ipVersion = "ipv6"
+        if configGlobal['ipv6NetworkMask'] > 0 and configGlobal['ipv6NetworkMask'] < 128:
+            ipv6NetMask = str(configGlobal['ipv6NetworkMask'])
+        else:
+            ipv6NetMask = "128"
+        ipInterface = ipaddress.ip_interface(ip.decode("utf-8") + "/" + ipv6NetMask )
+        ipNetwork   =  ipInterface.network
+        ipNetAddr   =  ipNetwork.network_address.exploded
+        ipBytes     = string.split(ipNetAddr, ':')
+    else:
+        syslog.syslog('greylistcheck: ipaddress version is invalid: "%s"' % ipAddr.version )
+        return ( 'defer', 'Service unavailable, error checking IP address. See /var/log/maillog for more information.' )
+
     ipPath = string.join(ipBytes, '/')
 
     if configGlobal['greylistByIPOnly'] > 0:
-        dir = os.path.join(greylistDir, ipPath)
+        dir = os.path.join(greylistDir, 'client_address', ipVersion, ipPath)
         path = os.path.join(dir, 'check_file')
     else:
         sender = data.get('sender')
@@ -193,9 +228,11 @@ def greylistcheck(data, configData, configGlobal):
             return((None, None))
         sender = tumgreyspfsupp.quoteAddress(sender)
         recipient = tumgreyspfsupp.quoteAddress(recipient)
-        dir = os.path.join(greylistDir, 'client_address', ipPath, 'greylist',
-                sender)
+        dir = os.path.join(greylistDir, 'client_address', ipVersion, ipPath, 'greylist', sender)
         path = os.path.join(dir, recipient)
+
+    if debugLevel >= 3:
+        syslog.syslog('greylistcheck: check_file full path: "%s"' % path)
 
     allowTime = configData.get('GREYLISTTIME', 600)
 
@@ -290,19 +327,35 @@ def blackholecheck(data, configData, configGlobal):
     ip = data.get('client_address')
     if ip == None:
         return((None, None))
-    ipPath = string.join(string.split(ip, '.'), '/')
-    dir = os.path.join(blackholeDir, 'ips', ipPath)
 
     recipient = data.get('recipient')
     if not recipient:
         return((None, None))
     recipient = tumgreyspfsupp.quoteAddress(recipient)
 
+    ipAddr = ipaddress.ip_address(ip.decode("utf-8"))
+
+    if debugLevel >= 2:
+        syslog.syslog('blackholecheck: client_address="%s",recipient="%s", ipVersion="%s"' %( ip, recipient, ipAddr.version ) )
+
+    if ipAddr.version == 4:
+        ipPath = string.join(string.split(ipAddr.exploded, '.'), '/')
+        dir = os.path.join(blackholeDir, 'ips', 'ipv4', ipPath)
+    elif ipAddr.version == 6:
+        ipPath = string.join(string.split(ipAddr.exploded, ':'), '/')
+        dir = os.path.join(blackholeDir, 'ips', 'ipv6', ipPath)
+    else:
+        syslog.syslog('blackholecheck: ipaddress version is invalid: "%s"' % ipAddr.version )
+        return ( 'defer', 'Service unavailable, error checking IP address. See /var/log/maillog for more information.' )
+
     #  add blackhole
     recipientPath = os.path.join(blackholeDir, 'addresses', recipient)
     if os.path.exists(recipientPath):
         if not os.path.exists(dir):
-            os.path.makedirs(dir)
+            os.makedirs(dir)
+
+    if debugLevel >= 2:
+        syslog.syslog('blackholecheck: recipient="%s", recipientPath="%s", directory="%s"' %( recipient, recipientPath, dir ) )
 
     #  check for existing blackhole entry
     if os.path.exists(dir):

--- a/tumgreyspf-clean
+++ b/tumgreyspf-clean
@@ -11,77 +11,136 @@ import os, re, string, syslog, sys, time
 sys.path.append('/usr/local/lib/tumgreyspf')
 import tumgreyspfsupp
 
-###################
-def syslogprint(s):
-	print s
-syslog.syslog = syslogprint
-
+syslog.openlog(os.path.basename(sys.argv[0]), syslog.LOG_PID, syslog.LOG_MAIL)
 
 ##################################
-def visit(config, dirname, fileList):
-	ospathisfile = os.path.isfile
-	ospathjoin = os.path.join
-	base = config['greylistBasedir']
-	rx = re.compile(r'^/?(\d+)/(\d+)/(\d+)/((\d+)/)?greylist/(.*)$')
-	rxIp = re.compile(r'^/?(\d+)/(\d+)/(\d+)/((\d+)/)?check_file')
-	didUnlink = 0
-	for file in fileList:
-		path = ospathjoin(dirname, file)
-		if not ospathisfile(path): continue
+def remove_expired_files(config, dirname, fileList):
+    ospathisfile = os.path.isfile
+    ospathjoin = os.path.join
+    base  = os.path.join(config['greylistDir'], 'client_address', config['proto'])
 
-		recipient = file
-		relative = path[len(base):]
-		if configGlobal['greylistByIPOnly'] > 0:
-			m = rxIp.match(relative)
-		else:
-			m = rx.match(relative)
-		if not m:
-			print 'Unknown path "%s" found in greylist directory.' % relative
-			continue
+    if config['proto'] == "ipv4":
+        rx   = re.compile(r'^/?(\d+)/(\d+)/(\d+)/(\d+)/greylist/(.+)/(.+)$')
+        rxIp = re.compile(r'^/?(\d+)/(\d+)/(\d+)/(\d+)/check_file')
+    elif config['proto'] == "ipv6":
+        rx   = re.compile(r'^/?([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/greylist/(.+)/(.+)$')
+        rxIp = re.compile(r'^/?([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/check_file')
+    else:
+        message = "Error - Invalid IP protocol"            
+        syslog.syslog('tumgreyspf-clean: "%s"' % message )
+        sys.exit(2)
 
-		#  get IP information
-		groups = m.groups()
-		ipList = list(groups[:3])
-		if groups[3] != None: ipList.append(groups[4])
-		else: ipList.append('0')
+    didUnlink = 0
+    for file in fileList:
+        path = ospathjoin(dirname, file)
+        if not ospathisfile(path): continue
 
-		ip = string.join(ipList, '.')
-		sender = groups[5]
+        if debugLevel:
+            syslog.syslog('tumgreyspf-clean: analyzing file "%s"' % path )
 
-		#  look up expration day
-		data = {
-				'envelope_sender' : tumgreyspfsupp.unquoteAddress(sender),
-				'envelope_recipient' : tumgreyspfsupp.unquoteAddress(recipient),
-				'client_address' : ip,
-				}
-		configData = tumgreyspfsupp.lookupConfig(config.get('configPath'),
-				data, config.copy())
-		expireTime = time.time() - (configData['GREYLISTEXPIREDAYS'] * 86400)
+        relative = path[len(base):]
+        #check for any configuration type 
+        m = rxIp.match(relative)
+        greylistByIPOnly = True;
+        if not m:
+            m = rx.match(relative)
+            greylistByIPOnly = False;
+        if not m:
+            syslog.syslog('tumgreyspf-clean: Unknown path "%s" found in greylist directory.' % relative )
+            continue
 
-		#  check for expiration
-		statData = os.stat(path)
-		mtime = statData[8]
-		ctime = statData[9]
-		expiredAuth = ctime < mtime and (time.time() - mtime) > (12 * 3600)
-		expiredAfterAuth = ctime < expireTime
+        #  get IP information
+        groups = m.groups()
 
-		#  check for expiration
-		if expiredAuth or expiredAfterAuth:
-			os.remove(path)
-			didUnlink = 1
+        if debugLevel:
+            syslog.syslog('tumgreyspf-clean: regex matches: "%s"' % str(groups) )
 
-	#  remove this directory and it's parents if empty
-	if didUnlink:
-		newDirname = dirname
-		while len(newDirname) > len(base):
-			try: os.rmdir(newDirname)
-			except OSError: break
-			newDirname = os.path.dirname(newDirname)
+        if config['proto'] == "ipv4":
+            ipList = list(groups[:4])
+            ip = string.join(ipList, '.')
+
+        elif config['proto'] == "ipv6":
+            ipList = list(groups[:8])
+            ip = string.join(ipList, ':')
+
+        if greylistByIPOnly:
+            data = {
+                    'client_address' : ip,
+                    }
+            sender = ""
+            recipient = ""
+
+            if debugLevel:
+                syslog.syslog('tumgreyspf-clean: looking for config to IP "%s"' % ip )
+        else:
+            if config['proto'] == "ipv4":   sender = groups[5]
+            elif config['proto'] == "ipv6": sender = groups[8]
+            recipient = file
+
+            #  look up expiration day
+            data = {
+                    'envelope_sender' : tumgreyspfsupp.unquoteAddress(sender),
+                    'envelope_recipient' : tumgreyspfsupp.unquoteAddress(recipient),
+                    'client_address' : ip,
+                    }
+            if debugLevel:
+                syslog.syslog('tumgreyspf-clean: looking for config to IP="%s", sender="%s", recipient="%s"'
+                                       %( ip, tumgreyspfsupp.unquoteAddress(sender), tumgreyspfsupp.unquoteAddress(recipient) ))
+
+        configData = tumgreyspfsupp.lookupConfig(config.get('configPath'), data, config.copy())
+        expireTime = time.time() - (configData['GREYLISTEXPIREDAYS'] * 86400)
+
+        #  check for expiration
+        statData = os.stat(path)
+        mtime = statData[8]
+        ctime = statData[9]
+        expiredAuth = ctime < mtime and (time.time() - mtime) > (12 * 3600)
+        expiredAfterAuth = ctime < expireTime
+
+        #  check for expiration
+        if expiredAuth or expiredAfterAuth:
+            if debugLevel:
+                syslog.syslog('tumgreyspf-clean: removing expired file: "%s"' % path )
+
+            os.remove(path)
+            didUnlink = 1
+        else:
+            if debugLevel:
+                syslog.syslog('tumgreyspf-clean: not removing valid file: "%s"' % path )
+
+    # always remove empty directories
+    if didUnlink or not fileList:
+        if debugLevel:
+            syslog.syslog('tumgreyspf-clean: trying to remove directory and parents: "%s"' % dirname )
+        newDirname = dirname
+        while len(newDirname) > len(base):
+            if debugLevel:
+                syslog.syslog('tumgreyspf-clean: trying to remove directory: "%s"' % newDirname )
+            try: os.rmdir(newDirname)
+            except OSError: break
+            newDirname = os.path.dirname(newDirname)
 
 
 ############################
 #  main code
-config = tumgreyspfsupp.processConfigFile()
-greylistBasedir = os.path.join(config['greylistDir'], 'client_address')
-config['greylistBasedir'] = greylistBasedir
-os.path.walk(greylistBasedir, visit, config)
+
+
+configGlobal = tumgreyspfsupp.processConfigFile()
+debugLevel = configGlobal.get('debugLevel', 0)
+if debugLevel:
+    syslog.syslog('tumgreyspf-clean: starting')
+
+#check ipv4 directory for expired files
+ipv4GreylistBasedir = os.path.join(configGlobal['greylistDir'], 'client_address', 'ipv4')
+configGlobal['proto'] = 'ipv4'
+if debugLevel:
+    syslog.syslog('tumgreyspf-clean: checking "%s" directory: "%s"' %( configGlobal['proto'], ipv4GreylistBasedir) )
+os.path.walk(ipv4GreylistBasedir, remove_expired_files, configGlobal)
+
+#check ipv6 directory for expired files
+ipv6GreylistBasedir = os.path.join(configGlobal['greylistDir'], 'client_address', 'ipv6')
+configGlobal['proto'] = 'ipv6'
+if debugLevel:
+    syslog.syslog('tumgreyspf-clean: checking "%s" directory: "%s"' %( configGlobal['proto'], ipv6GreylistBasedir) )
+os.path.walk(ipv6GreylistBasedir, remove_expired_files, configGlobal)
+

--- a/tumgreyspf-stat
+++ b/tumgreyspf-stat
@@ -10,86 +10,127 @@ import os, re, string, syslog, sys, time
 sys.path.append('/usr/local/lib/tumgreyspf')
 import tumgreyspfsupp
 
-###################
-def syslogprint(s):
-	print s
-syslog.syslog = syslogprint
-
+syslog.openlog(os.path.basename(sys.argv[0]), syslog.LOG_PID, syslog.LOG_MAIL)
 
 ##################################
-def visit(config, dirname, fileList):
-	ospathisfile = os.path.isfile
-	ospathjoin = os.path.join
-	base = config['greylistBasedir']
-	rx = re.compile(r'^/?(\d+)/(\d+)/(\d+)/(\d+)/greylist/(.*)$')
-	if config['ignoreLastByte'] > 0:
-		rx = re.compile(r'^/?(\d+)/(\d+)/(\d+)/greylist/(.*)$')
-	didUnlink = 0
-	for file in fileList:
-		path = ospathjoin(dirname, file)
-		if not ospathisfile(path): continue
+def tumgreyspf_stats(config, dirname, fileList):
+    ospathisfile = os.path.isfile
+    ospathjoin = os.path.join
+    base  = os.path.join(config['greylistDir'], 'client_address', config['proto'])
 
-		recipient = file
-		relative = dirname[len(base):]
-		m = rx.match(relative)
-		if not m:
-			print 'Unknown path "%s" found in greylist directory.' % relative
-			continue
-		ip = string.join(m.groups()[:-1], '.')
-		sender = m.groups()[-1]
+    if config['proto'] == "ipv4":
+        rx   = re.compile(r'^/?(\d+)/(\d+)/(\d+)/(\d+)/greylist/(.+)/(.+)$')
+        rxIp = re.compile(r'^/?(\d+)/(\d+)/(\d+)/(\d+)/check_file')
+    elif config['proto'] == "ipv6":
+        rx   = re.compile(r'^/?([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/greylist/(.+)/(.+)$')
+        rxIp = re.compile(r'^/?([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/([\d\w]+)/check_file')
+    else:
+        message = "Error - Invalid IP protocol"            
+        syslog.syslog('tumgreyspf-stats: "%s"' % message )
+        sys.exit(2)
 
-		#  look up expration day
-		data = {
-				'envelope_sender' : tumgreyspfsupp.unquoteAddress(sender),
-				'envelope_recipient' : tumgreyspfsupp.unquoteAddress(recipient),
-				'client_address' : ip,
-				}
-		configData = tumgreyspfsupp.lookupConfig(config.get('configPath'),
-				data, config.copy())
-		expireTime = time.time() - (configData['GREYLISTEXPIREDAYS'] * 86400)
+    for file in fileList:
+        path = ospathjoin(dirname, file)
+        if not ospathisfile(path): continue
 
-		#  check
-		statData = os.stat(path)
-		mtime = statData[8]
-		ctime = statData[9]
-		now = time.time()
+        if debugLevel:
+            syslog.syslog('tumgreyspf-stats: analyzing file "%s"' % path )
 
-		#  status information
-		stats = ''
-		if ctime < mtime:
-			stats = stats + 'Blocked,'
-		if mtime > now:
-			stats = stats + 'Pending,'
-		if stats:
-			stats = ' (%s)' % stats[:-1]
+        relative = path[len(base):]
+        #check for any configuration type 
+        m = rxIp.match(relative)
+        greylistByIPOnly = True;
+        if not m:
+            m = rx.match(relative)
+            greylistByIPOnly = False;
+        if not m:
+            syslog.syslog('tumgreyspf-stats: Unknown path "%s" found in greylist directory.' % relative )
+            continue
 
-		def prettyseconds(seconds):
-			for prettySeconds, prettyDescription in (
-					( 86400, 'd' ),
-					( 3600, 'h' ),
-					( 60, 'm' ),
-					):
-				if seconds > prettySeconds:
-					return('%d%s' % ( seconds / prettySeconds, prettyDescription ))
-			return('%ss' % seconds)
+        #  get IP information
+        groups = m.groups()
 
-		#  display information
-		print ('IP=%s SENDER=%s RECIPIENT=%s STARTS=%s LAST=%s EXPIRESIN=%s%s'
-				% ( ip, sender, recipient, prettyseconds(now - mtime),
-					prettyseconds(now - ctime),
-					prettyseconds(int(expireTime - now)), stats ))
+        if debugLevel:
+            syslog.syslog('tumgreyspf-stats: regex matches: "%s"' % str(groups) )
 
+        if config['proto'] == "ipv4":
+            ipList = list(groups[:4])
+            ip = string.join(ipList, '.')
+
+        elif config['proto'] == "ipv6":
+            ipList = list(groups[:8])
+            ip = string.join(ipList, ':')
+
+        if greylistByIPOnly:
+            data = {
+                    'client_address' : ip,
+                    }
+            sender = ""
+            recipient = ""
+
+            if debugLevel:
+                syslog.syslog('tumgreyspf-stats: looking for config to IP "%s"' % ip )
+        else:
+            if config['proto'] == "ipv4":   sender = groups[5]
+            elif config['proto'] == "ipv6": sender = groups[8]
+            recipient = file
+
+            #  look up expiration day
+            data = {
+                    'envelope_sender' : tumgreyspfsupp.unquoteAddress(sender),
+                    'envelope_recipient' : tumgreyspfsupp.unquoteAddress(recipient),
+                    'client_address' : ip,
+                    }
+            if debugLevel:
+                syslog.syslog('tumgreyspf-stats: looking for config to IP="%s", sender="%s", recipient="%s"'
+                                       %( ip, tumgreyspfsupp.unquoteAddress(sender), tumgreyspfsupp.unquoteAddress(recipient) ))
+
+        configData = tumgreyspfsupp.lookupConfig(config.get('configPath'), data, config.copy())
+
+        #  check info
+        statData = os.stat(path)
+        mtime = statData[8]
+        ctime = statData[9]
+        now = time.time()
+        expireIn = mtime + (configData['GREYLISTEXPIREDAYS'] * 86400) - now
+
+        #  status information
+        stats = ''
+        if mtime >= now:
+            stats = 'Pending'
+        if mtime < now:
+            stats = 'Allowed'
+        #if ctime < mtime:
+        #    stats = 'Blocked'
+
+        #  display information
+        print ('STATUS=(%s) SENDER=(%s) RECIPIENT=(%s) ALLOWED=(%s)ago LASTMAIL=(%s)ago EXPIRESIN=(%s) IP=(%s)'
+                        % ( stats, sender, recipient, 
+                                tumgreyspfsupp.prettyseconds(now - mtime),
+                                tumgreyspfsupp.prettyseconds(now - ctime),
+                                tumgreyspfsupp.prettyseconds(expireIn),
+                                ip ))
 
 ############################
 #  main code
-config = tumgreyspfsupp.processConfigFile()
-greylistBasedir = os.path.join(config['greylistDir'], 'client_address')
-config['greylistBasedir'] = greylistBasedir
-try:
-	os.path.walk(greylistBasedir, visit, config)
 
-#  ignore interrupts and errors writing stdout
-except IOError, e:
-	if e.errno != 32: raise
-except KeyboardInterrupt:
-	pass
+
+configGlobal = tumgreyspfsupp.processConfigFile()
+debugLevel = configGlobal.get('debugLevel', 0)
+if debugLevel:
+    syslog.syslog('tumgreyspf-stats: starting')
+
+#check ipv4 directory for expired files
+ipv4GreylistBasedir = os.path.join(configGlobal['greylistDir'], 'client_address', 'ipv4')
+configGlobal['proto'] = 'ipv4'
+if debugLevel:
+    syslog.syslog('tumgreyspf-stats: checking "%s" directory: "%s"' %( configGlobal['proto'], ipv4GreylistBasedir) )
+os.path.walk(ipv4GreylistBasedir, tumgreyspf_stats, configGlobal)
+
+#check ipv6 directory for expired files
+ipv6GreylistBasedir = os.path.join(configGlobal['greylistDir'], 'client_address', 'ipv6')
+configGlobal['proto'] = 'ipv6'
+if debugLevel:
+    syslog.syslog('tumgreyspf-stats: checking "%s" directory: "%s"' %( configGlobal['proto'], ipv6GreylistBasedir) )
+os.path.walk(ipv6GreylistBasedir, tumgreyspf_stats, configGlobal)
+

--- a/tumgreyspf.conf
+++ b/tumgreyspf.conf
@@ -24,19 +24,31 @@ greylistDir = '/var/local/lib/tumgreyspf/data'
 #  perl version available from http://www.openspf.com/ or the
 #  "spfquery-static" program built from libspf2, also available from
 #  http://www.openspf.com/
+#spfqueryPath = '/usr/bin/spfquery'
 spfqueryPath = '/usr/local/lib/tumgreyspf/spfquery'
 
 #  Directory where the blackhole information goes.  "ips" sub-directory
 #  contains IPs that have touched us with a bad address.  "addresses"
 #  sub-directory has a file per address named after the bad addresses.
-blackholeDir = '/var/lib/tumgreyspf/blackhole'
+blackholeDir = '/var/local/lib/tumgreyspf/blackhole'
 
 #  If set to 1, the last byte of the sender's IP address will be ignored.
 #  So, if mail from 1.2.3.4 was delayed, then redelivered by 1.2.3.58,
 #  the message would be accepted as if it came from the same server.
 #  This allows pools of mail servers to appear as one, increasing
 #  compatibility with large email services.
-ignoreLastByte = 1
+#  DEPRECATED OPTION, in favor of ipv4NetworkMask.
+###ignoreLastByte = 1
+
+#  Define the network mask to allow IPv4 addresses on greylist service.
+#  A value of 32 means a specific file and directory for each IPv4 address
+#  A value of 24 means a file and directory for each class C network
+ipv4NetworkMask = 32
+
+#  Define the network mask to allow IPv6 addresses on greylist service.
+#  A value of 128 means a specific file and directory for each IPv6 address
+#  A value of 64 means a file and directory for each IPv6 network to block
+ipv6NetworkMask = 64
 
 #  If set to one, message will only be greylisted by the IP of the
 #  originating machine, not by IP, sender address, and reciever address


### PR DESCRIPTION
Hello Sean

I have made a lot of changes in tumgreyspf, mainly to support IPv6 in the greylisting and blackhole checks.

I also updated tumgrey-stat and tumgrey-clean, to deal with the IPv6 files and directories, and to cleanup all the expired files, doesn't matter if the greylist check is IP only, or IP + recipient.

I know that the changes are extensive, and I probably changes one or two things that I shouldn't, but I am deploying an new IPv6 mail MX, and I want to continue using tumgreyspf.

The code was tested in Ubuntu 15.10, with python 2.7.10 installed via APT.
